### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -4,6 +4,8 @@ on:
   push:
     branches:
       - main
+permissions:
+  contents: read
 jobs:
   build-and-deploy:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/vunifyLTD/VDEADLINE/security/code-scanning/1](https://github.com/vunifyLTD/VDEADLINE/security/code-scanning/1)

To fix the issue, add a `permissions` block at the root of the workflow to explicitly define the minimal permissions required. Based on the workflow's steps, it primarily involves checking out code, setting up Node.js, installing dependencies, building a React app, and deploying via FTP. None of these steps require write access to the repository. Therefore, the `permissions` block should be set to `contents: read` to limit the GITHUB_TOKEN's access to read-only.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
